### PR TITLE
Local transmission of B.1.1.7 in Austria

### DIFF
--- a/grinch/data/local_imported_b117.csv
+++ b/grinch/data/local_imported_b117.csv
@@ -40,7 +40,7 @@ Cyprus,2020-12-20,,0,travellers,https://cyprus-mail.com/2021/01/03/coronavirus-n
 Thailand,2021-01-03,,0,travellers,https://www.thestar.com.my/aseanplus/aseanplus-news/2021/01/03/thailand-finds-new-strain-of-covid-19-from-uk-in-four-britons
 Greece,2021-01-03,,0,travellers,https://www.keeptalkinggreece.com/2021/01/03/covid19-mutated-strain-greece-travelers-uk/#.X_IT0OugNCg.twitter
 Jamaica,2020-12-21,,0,travellers,https://www.thestkittsnevisobserver.com/new-corona-strain-arrives-in-jamaica-on-last-uk-flight/
-Austria,2021-01-04,,0,,https://www.sn.at/panorama/wissen/live-corona-mutationen-sind-in-oesterreich-angekommen-97891537
+Austria,2021-01-04,2021-01-18,1,community_sequencing,https://www.sn.at/panorama/wissen/live-corona-mutationen-sind-in-oesterreich-angekommen-97891537 | https://www.ots.at/presseaussendung/OTS_20210118_OTS0147/anschober-ergebnisse-der-vollsequenzierungen-bestaetigen-b117-verdacht-bei-grossteil-der-geprueften-faelle
 Iran,2021-01-05,,0,travellers,https://www.jpost.com/breaking-news/iran-finds-first-case-of-new-virus-variant-in-traveler-from-uk-654329
 Philippines,2020-12-22,,,,https://cnnphilippines.com/news/2021/1/6/Hong-Kong-detects-UK-COVID-19-variant-from-Manila-outbound-passenger-.html
 Oman,2021-01-05,,0,travellers,https://www.reuters.com/article/us-health-coronavirus-oman-idUSKBN29A1G9


### PR DESCRIPTION
Press release by the ministry of health confirming sequencing of 46 cases of B.1.1.7 lineage in Austria on the 18th of January 2021. 
Including cases in a care home facility in Vienna. 
https://www.ots.at/presseaussendung/OTS_20210118_OTS0147/anschober-ergebnisse-der-vollsequenzierungen-bestaetigen-b117-verdacht-bei-grossteil-der-geprueften-faelle

Further confirmation of prevalence of B.1.1.7 in a sample of 66 out of 539 samples in Vienna on the 22nd of January:
https://www.wienerzeitung.at/nachrichten/chronik/wien/2089738-B.1.1.7-in-zwoelf-Prozent-der-Wiener-Proben.html

Thank you!